### PR TITLE
Add explicit build targets to support most modern AMD GPUs

### DIFF
--- a/build/Dockerfile.onnxruntime
+++ b/build/Dockerfile.onnxruntime
@@ -55,7 +55,7 @@ RUN python3.11 tools/ci_build/build.py \
     --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
     --cmake_extra_defines onnxruntime_BUILD_TESTS=OFF \
     --cmake_extra_defines CMAKE_CXX_FLAGS=-Wno-error=unused-function \
-    --cmake_extra_defines MAKE_HIP_ARCHITECTURES="gfx900;gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gx1103;gfx1200;gfx1201" \
+    --cmake_extra_defines MAKE_HIP_ARCHITECTURES="gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201" \
     --update \
     --build
 

--- a/build/Dockerfile.onnxruntime
+++ b/build/Dockerfile.onnxruntime
@@ -55,6 +55,7 @@ RUN python3.11 tools/ci_build/build.py \
     --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
     --cmake_extra_defines onnxruntime_BUILD_TESTS=OFF \
     --cmake_extra_defines CMAKE_CXX_FLAGS=-Wno-error=unused-function \
+     --cmake_extra_defines MAKE_HIP_ARCHITECTURES="gfx900;gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gx1103;gfx1200;gfx1201" \
     --update \
     --build
 

--- a/build/Dockerfile.onnxruntime
+++ b/build/Dockerfile.onnxruntime
@@ -55,7 +55,7 @@ RUN python3.11 tools/ci_build/build.py \
     --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
     --cmake_extra_defines onnxruntime_BUILD_TESTS=OFF \
     --cmake_extra_defines CMAKE_CXX_FLAGS=-Wno-error=unused-function \
-     --cmake_extra_defines MAKE_HIP_ARCHITECTURES="gfx900;gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gx1103;gfx1200;gfx1201" \
+    --cmake_extra_defines MAKE_HIP_ARCHITECTURES="gfx900;gfx906;gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gx1103;gfx1200;gfx1201" \
     --update \
     --build
 


### PR DESCRIPTION
With this PR, I am hoping to upstream changes to support most modern AMD GPU architectures.  This is done so by adding a new build flag for ORT called `MAKE_HIP_ARCHITECTURES`. This flag takes in a `;` delimited string where each value is a GPU arch.

By doing so, this will add support for most GPU architectures from Vega 10 to RDNA 4.

I have tested these changes locally and I am able to run ORT w/ ROCm 7.1 and my AMD Instinct Mi50 (Vega 20, gfx906).