### PR TITLE
Use onnxruntime 1.23.2

### DIFF
--- a/build/Dockerfile.onnxruntime
+++ b/build/Dockerfile.onnxruntime
@@ -38,7 +38,7 @@ RUN mkdir -p /opt/rocm/.info && \
 
 # Clone ONNX Runtime (use version 1.23.1 with MIGraphX support)
 WORKDIR /
-RUN git clone --single-branch --branch v1.23.1 --recursive https://github.com/Microsoft/onnxruntime onnxruntime
+RUN git clone --single-branch --branch v1.23.2 --recursive https://github.com/Microsoft/onnxruntime onnxruntime
 
 WORKDIR /onnxruntime
 
@@ -55,7 +55,6 @@ RUN python3.11 tools/ci_build/build.py \
     --cmake_extra_defines onnxruntime_BUILD_UNIT_TESTS=OFF \
     --cmake_extra_defines onnxruntime_BUILD_TESTS=OFF \
     --cmake_extra_defines CMAKE_CXX_FLAGS=-Wno-error=unused-function \
-    --cmake_extra_defines MAKE_HIP_ARCHITECTURES="gfx908;gfx90a;gfx942;gfx950;gfx1030;gfx1100;gfx1101;gfx1200;gfx1201" \
     --update \
     --build
 


### PR DESCRIPTION
- Bump `onnxruntime` to `1.23.2`
- Remove redundant `MAKE_HIP_ARCHITECTURES` flag
  - The correct flag is `CMAKE_HIP_ARCHITECTURES` (See [cmake](https://cmake.org/cmake/help/latest/variable/CMAKE_HIP_ARCHITECTURES.html))
  - This flag is not used by onnxruntime since `1.23.0` (See https://github.com/microsoft/onnxruntime/pull/25181)
  - Supported architectures are directly related to the targets of migraphx, included by ROCm, (See [targets](https://github.com/ROCm/AMDMIGraphX/blob/rocm-7.2.0/Jenkinsfile#L4))
  - For #2, `gfx906` is an included target by migraphx in ROCm `7.2.0`